### PR TITLE
feat(words): add rtmdet

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -1597,6 +1597,7 @@
     "rstar",
     "rsyslog",
     "RTKLIB",
+    "rtmdet",
     "RTNL",
     "RTPS",
     "rtree",


### PR DESCRIPTION
This PR adds word `rtmdet`.

`rtmdet` is a instance segmentation model and this word used in https://github.com/autowarefoundation/autoware.universe/pull/8165#

paper: https://arxiv.org/abs/2212.07784