### PR TITLE
feat: ignore people names in NOTE

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -220,6 +220,7 @@
       "ignoreRegExpList": [
         "Copyright (\\(c\\))?.+$",
         "FIXME( )?\\(.+?\\)",
+        "NOTE( )?\\(.+?\\)",
         "TODO( )?\\(.+?\\)"
       ]
     },


### PR DESCRIPTION
## Description

ignore people names in `NOTE(<name>)` comments

## Related links

**Parent Issue/PR:**

None

**Links to the definitions of the words added:**

A widely seen way of writing comments with names attached.
https://github.com/search?q=%22%2F%2F+NOTE%28%22+language%3AC%2B%2B&type=code&l=C%2B%2B
Compared to normal comments, this is useful because it makes it clear who is responsible for the comment.

Here, I am not adding this pattern because I want to ignore NOTE comments, but to ignore `<name>` in `NOTE(<name>)`.

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## Notes for reviewers

Some people using `NOTE(<name>)` for taking notes with their own names.
https://github.com/search?q=org%3Aautowarefoundation+NOTE%28&type=code

### my dictionary maintaining policy for personal names

When I was maintaining `tier4/autoware-spell-check-dict`, my maintaining policy for people name was as follows:

- Generally, I do not add personal names to the dictionary
  - I ignore patterns in which people names appear, making the dictionary robust to new contributors, like this PR.
- Contributor names that are not matched by a pattern are added to the "people_names" dictionary in `tier4/cspell-dicts`.
- Names that only appear in a few places, such as the author names of papers referenced in the implementation, can be ignored on the spot by using `cspell: ignore <name>` in the code.