### PR TITLE
feat: add python's nans and itemize to the spell check

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -98,7 +98,9 @@
         "imageio",
         "linewidth",
         "maintainer(_email)?=.*$",
-        "mimsave"
+        "mimsave",
+        "itemsize",
+        "nans"
       ]
     },
     {

--- a/.cspell.json
+++ b/.cspell.json
@@ -96,10 +96,10 @@
       "ignoreRegExpList": [
         "author(_email)?=.*$",
         "imageio",
+        "itemsize",
         "linewidth",
         "maintainer(_email)?=.*$",
         "mimsave",
-        "itemsize",
         "nans"
       ]
     },


### PR DESCRIPTION
## Description
- Add python's keywords 'itemsize' and 'nans' to spell check dict
## Related links

**Parent Issue/PR:**

- PR

**Links to the definitions of the words added:**

- Word

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## Notes for reviewers

Reference links
'itemsize' is from numpy ndarray https://numpy.org/doc/2.2/reference/generated/numpy.ndarray.itemsize.html
'nans' is from sensor_msgs_py.point_cloud2 https://docs.ros.org/en/iron/p/sensor_msgs_py/sensor_msgs_py.point_cloud2.html
