### PR TITLE
feat(words): add opengl

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -1340,6 +1340,7 @@
     "opencl",
     "opencontainers",
     "opencv",
+    "opengl",
     "openlist",
     "openmp",
     "openni",


### PR DESCRIPTION
## Description
To avoid inevitable spell warnings in future pull-requests, this pull-request adds the module name related with OpenGL to words section in cspell.json.

## Related links

**Parent Issue/PR:**

Parent Issue: N/A

- PR
  - https://github.com/autowarefoundation/autoware_tools/pull/301
  - https://github.com/autowarefoundation/autoware_tools/actions/runs/17751185185/job/50446249442?pr=301
  - Added a newer word introduced by the `autoware_position_error_evaluator` package.

