### PR TITLE
feat(.cspell.json): add dict-data-science and enable en-US and en-GB

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -63,6 +63,9 @@
     "@tier4/cspell-dicts/organization-names/cspell-ext.json",
     "@tier4/cspell-dicts/people-names/cspell-ext.json"
   ],
+  "dictionaries": [
+    "data-science"
+  ],
   "languageSettings": [
     {
       "languageId": "dockerfile",

--- a/.cspell.json
+++ b/.cspell.json
@@ -1,6 +1,6 @@
 {
   "version": "0.2",
-  "language": "en",
+  "language": "en, en-US, en-GB",
   "allowCompoundWords": false,
   "ignorePaths": [
     "**/*.caffemodel",
@@ -54,6 +54,7 @@
   ],
   "import": [
     "@cspell/dict-cpp/cspell-ext.json",
+    "@cspell/dict-data-science/cspell-ext.json",
     "@cspell/dict-en-gb/cspell-ext.json",
     "@cspell/dict-en_us/cspell-ext.json",
     "@cspell/dict-software-terms/cspell-ext.json",

--- a/format_cspell_json/format_cspell_json.py
+++ b/format_cspell_json/format_cspell_json.py
@@ -56,6 +56,7 @@ def format_cspell_json(cspell_json: Dict) -> Dict:
             "ignorePaths",
             "ignoreRegExpList",
             "import",
+            "dictionaries",
             "languageSettings",
             "overrides",
             "flagWords",


### PR DESCRIPTION
## Description

- https://www.npmjs.com/package/@cspell/dict-data-science
  - https://github.com/streetsidesoftware/cspell-dicts/tree/main/dictionaries/data-science

### Reasons

- **data-science** for the word [`explainability`](https://github.com/streetsidesoftware/cspell-dicts/blob/a62a6ca1ca7d568f57c055654ad36684aa23fccb/dictionaries/data-science/dict/data-science.txt#L163)

Related PR:
- https://github.com/autowarefoundation/autoware-documentation/pull/687

<img width="1074" height="794" alt="image" src="https://github.com/user-attachments/assets/94c57469-968e-4c06-b397-1811348eb0c3" />

## Notes for reviewers

Running `npm install -g cspell@latest` and `cspell trace categorised` you can see it exists in en-gb dictionary but it was not finding even though it was imported.

<img width="978" height="434" alt="image" src="https://github.com/user-attachments/assets/46f6003c-9b4d-42af-965a-e0dd39ec5111" />

By adding `"language": "en, en-US, en-GB"` we enable these languages and it now finds these words.

Reference:
- https://cspell.org/docs/dictionaries/searching-dictionaries