### PR TITLE
chore(FlagWords): remove Tier4 from the flag words

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -277,7 +277,6 @@
     "planing",
     "ROS1",
     "ROS2",
-    "Tier4",
     "TIERIV",
     "TierIV",
     "VSCode"


### PR DESCRIPTION
## Description
Remove the word: `Tier4` from the FlagWords since it has proper use cases from `t4-devkit`. For example, [here](https://github.com/tier4/autoware-ml/pull/21/changes#diff-4952b7889ebd5b3c6a2df3945ab930d8fd66402a67914fceb9747aada1a1b9b2R7)
 