### PR TITLE
feat: add "startswith" to dictionary

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -1371,6 +1371,7 @@
     "sregex",
     "sshpass",
     "stairstep",
+    "startswith",
     "startuml",
     "staticmethod",
     "statustip",


### PR DESCRIPTION
- Adds `startswith` to `.cspell.json`.

## Why

Used as a builtin in two common contexts:

- jq: [`startswith`](https://jqlang.org/manual/#startswith) — "Outputs `true` if `.` starts with the given string argument."
- Python: [`str.startswith`](https://docs.python.org/3/library/stdtypes.html#str.startswith) — "Return `True` if string starts with the prefix, otherwise return `False`."

---

- Encountered in autowarefoundation/autoware#7034.