### PR TITLE
ci(pre-commit): quarterly schedule, pin markdownlint-cli, bump biome

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,7 @@
 ci:
   autofix_commit_msg: "ci(pre-commit): autofix"
-  autoupdate_commit_msg: "ci(pre-commit): autoupdate"
+  autoupdate_commit_msg: "ci(pre-commit): quarterly autoupdate"
+  autoupdate_schedule: quarterly
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -18,7 +19,8 @@ repos:
         args: [--markdown-linebreak-ext=md]
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.48.0
+    # Pinned: v0.48.0 requires Node ^24.12, but pre-commit.ci ships v24.9.0 (EBADENGINE).
+    rev: v0.47.0
     hooks:
       - id: markdownlint
         args: [-c, .markdownlint.yaml, --fix]
@@ -40,7 +42,7 @@ repos:
         args: [-w, -s, -i=4]
 
   - repo: https://github.com/biomejs/pre-commit
-    rev: v2.4.11 # Use the sha / tag you want to point at
+    rev: v2.4.12
     hooks:
       - id: biome-check
 


### PR DESCRIPTION
## Summary
- Switch pre-commit.ci autoupdate cadence from weekly (default) to quarterly to reduce PR noise.
- Pin `markdownlint-cli` to v0.47.0. v0.48.0 requires Node `^24.12`, but pre-commit.ci's runner ships Node v24.9.0, which made the hook fail to install (`EBADENGINE`). Revisit once pre-commit.ci updates Node.
- Carry over the biome v2.4.11 → v2.4.12 bump.

Failing run that motivated the pin: https://results.pre-commit.ci/run/github/895048552/1776531948.kIggFs4DT8yOSBv2Cj70bg

## Test plan
- [ ] pre-commit.ci run on this PR is green.