### PR TITLE
feat: add "huggingface" to dictionary

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -750,6 +750,7 @@
     "hspace",
     "hstack",
     "hsub",
+    "huggingface",
     "hwmon",
     "hypot",
     "iarchive",


### PR DESCRIPTION
Adds `huggingface` to the dictionary.

Needed by autowarefoundation/autoware#7188, which adds the `ansible/roles/huggingface_cli` role for the Hugging Face CLI. The `spell-check-differential` workflow flags `huggingface` as an unknown word in `ansible/roles/artifacts/meta/main.yaml` and `ansible/roles/huggingface_cli/`.

`huggingface` is the canonical lowercase spelling of the Hugging Face brand (e.g. `huggingface.co`, the `huggingface_hub` package, the `huggingface-cli` command).